### PR TITLE
Fixed the travis ci badge to actually link back to travis-ci.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
-.. image:: https://secure.travis-ci.org/raxsavvy/margarine.png
-
+.. image:: https://secure.travis-ci.org/raxsavvy/margarine.png?branch=master
+   :target: http://travis-ci.org/raxsavvy/margarine
+   
 Introduction
 ============
 


### PR DESCRIPTION
Fixed the travis ci badge to actually link back to travis-ci.org
